### PR TITLE
Fixed: CSP style src error

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -95,7 +95,7 @@ ContainerManager.prototype._makeDivNode = function (container) {
         node.style.setAttribute('cssText', keyStr);
     }
     else {
-        node.setAttribute('style', keyStr);
+        node.style = keyStr;
     }
 
     node.setAttribute('aria-hidden', 'true');
@@ -112,7 +112,7 @@ ContainerManager.prototype._makeDivNode = function (container) {
             this.svgRoot.appendChild(node);
         }
         node = container.svgText;
-        node.setAttribute('style', keyStr);
+        node.style = keyStr;
         
 
         node.textContent = slLib.testStrAvg; // A test string.


### PR DESCRIPTION
Issue: Inline CSS provided by using setAttribute('style') which violates the CSP (Content Security Policy) style-src.

Fixes: Provided inline CSS with different method.

Ticket - https://fusioncharts.jira.com/browse/SUPPORT-2368